### PR TITLE
Add release build github action

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -1,7 +1,7 @@
 name: build-and-release
 
 on:
-  - workflow_dispatch
+  workflow_dispatch
 
 jobs:
   check_main:


### PR DESCRIPTION
DONT MERGE THIS YET! 

It adds a CI script that build wheels for multiple targets. Once we want to start releasing we should merge this and also add a pypi API to key to automate uploads