### PR TITLE
Remove logging & track reverts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,22 +163,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
-
-[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
-
-[[package]]
-name = "arc-swap"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
 name = "ark-ff"
@@ -1881,16 +1869,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7574c1cf36da4798ab73da5b215bbf444f50718207754cb522201d78d1cd0ff2"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,19 +1913,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "ndarray"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "rawpointer",
 ]
 
 [[package]]
@@ -2071,21 +2036,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "numpy"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef41cbb417ea83b30525259e30ccef6af39b31c240bda578889494c5392d331"
-dependencies = [
- "libc",
- "ndarray",
- "num-complex",
- "num-integer",
- "num-traits",
- "pyo3",
- "rustc-hash",
 ]
 
 [[package]]
@@ -2452,17 +2402,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pyo3-log"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c10808ee7250403bedb24bc30c32493e93875fef7ba3e4292226fe924f398bd"
-dependencies = [
- "arc-swap",
- "log",
- "pyo3",
-]
-
-[[package]]
 name = "pyo3-macros"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2545,12 +2484,6 @@ checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core",
 ]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
@@ -2835,7 +2768,6 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "anyhow",
  "assert_approx_eq",
  "db",
  "ethereum-types",
@@ -3834,9 +3766,7 @@ dependencies = [
  "alloy-sol-types",
  "db",
  "fastrand",
- "numpy",
  "pyo3",
- "pyo3-log",
  "revm",
  "rust_sim",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -763,11 +762,9 @@ checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 name = "db"
 version = "0.1.0"
 dependencies = [
- "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-types",
  "async-trait",
- "auto_impl",
  "ethers-core",
  "ethers-middleware",
  "ethers-providers",
@@ -775,14 +772,12 @@ dependencies = [
  "futures",
  "hex",
  "itertools 0.11.0",
- "parking_lot",
  "reqwest",
  "revm",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
- "tracing",
  "url",
 ]
 

--- a/core/db/Cargo.toml
+++ b/core/db/Cargo.toml
@@ -8,7 +8,6 @@ revm = { workspace = true, features = ["std", "serde"] }
 
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
-alloy-json-abi = "0.4.2"
 
 ethers-core.workspace = true
 ethers-providers.workspace = true
@@ -23,17 +22,12 @@ hex.workspace = true
 eyre = "0.6"
 thiserror = "1"
 
-# Logging
-tracing = "0.1"
-
 # Threading/futures
 tokio.workspace = true
-parking_lot = "0.12"
 futures.workspace = true
 
 # Misc
 url = "2"
-auto_impl = "1"
 itertools = "0.11.0"
 async-trait = "0.1.74"
 reqwest = { version = "0.11.22", default-features = false }

--- a/core/db/src/fork_db.rs
+++ b/core/db/src/fork_db.rs
@@ -8,7 +8,6 @@ use alloy_primitives::{keccak256, Bytes};
 pub use ethers_core::types::BlockNumber;
 use ethers_core::types::{BigEndianHash, Block, BlockId, NameOrAddress, H256};
 use ethers_providers::{Middleware, Provider, ProviderError};
-use eyre::anyhow;
 use revm::db::in_memory_db::DbAccount;
 use revm::db::{AccountState, DatabaseCommit};
 use revm::primitives::{
@@ -43,11 +42,12 @@ impl ForkDb {
             .build()
             .unwrap();
 
-        let block = rt
-            .block_on(provider.get_block(block_number))
-            .unwrap()
-            .ok_or(anyhow!("failed to retrieve block"))
-            .unwrap();
+        let block = rt.block_on(provider.get_block(block_number)).unwrap();
+
+        let block = match block {
+            Some(b) => b,
+            None => panic!("Could not retrieve block"),
+        };
 
         let mut contracts = HashMap::new();
         contracts.insert(KECCAK_EMPTY, Bytecode::new());

--- a/core/db/src/lib.rs
+++ b/core/db/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate tracing;
-
 mod db;
 mod error;
 mod fork_db;

--- a/core/rust_sim/Cargo.toml
+++ b/core/rust_sim/Cargo.toml
@@ -21,7 +21,6 @@ futures.workspace = true
 
 kdam = "0.3.0"
 log = "0.4.19"
-anyhow = "1.0.75"
 
 sim-macros = { path="../macros" }
 db = { path="../db" }

--- a/core/rust_sim/src/contract/structs.rs
+++ b/core/rust_sim/src/contract/structs.rs
@@ -31,6 +31,8 @@ pub struct TransactionResult {
 
 /// Wraps event logs with additional event information
 pub struct Event {
+    /// If the event was successful
+    pub success: bool,
     /// Name of the function being called.
     pub function_selector: [u8; 4],
     /// Event data

--- a/core/rust_sim/src/network/mod.rs
+++ b/core/rust_sim/src/network/mod.rs
@@ -247,9 +247,7 @@ impl<D: DB> Network<D> {
             execution_result,
             check_call,
         );
-        if let Some(event) = result.events {
-            self.last_events.push(event)
-        }
+        self.last_events.push(result)
     }
 
     pub fn process_transactions(&mut self, transactions: Vec<Transaction>, step: usize) {

--- a/core/rust_sim/src/network/mod.rs
+++ b/core/rust_sim/src/network/mod.rs
@@ -3,7 +3,6 @@ use crate::contract::{Event, Transaction};
 use crate::utils::Eth;
 use alloy_primitives::{Address, Uint, B256, U256};
 use alloy_sol_types::SolCall;
-use anyhow::Result;
 use db::{ForkDb, LocalDB, Requests, DB};
 pub use ethereum_types::U64;
 use log::debug;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "eth-hash[pycryptodome] >= 0.5.2",
   "joblib >= 1.3.2",
   "py-solc-x >= 2.0.2",
+  "pandas >= 2.2.0",
 ]
 
 [tool.hatch.envs.dev]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,9 +14,7 @@ alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 fastrand.workspace = true
 
-numpy = "0.20.0"
 pyo3 = { version="0.20.0", features = ["extension-module"] }
-pyo3-log = "0.9.0"
 
 rust_sim = { path = "../core/rust_sim" }
 db = { path = "../core/db" }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,6 +1,5 @@
 mod sim;
 mod types;
-use pyo3_log::{Caching, Logger};
 
 use pyo3::prelude::*;
 
@@ -11,9 +10,7 @@ use pyo3::prelude::*;
 ///
 #[pymodule]
 #[pyo3(name = "envs")]
-fn verbs(py: Python<'_>, m: &PyModule) -> PyResult<()> {
-    let _ = Logger::new(py, Caching::LoggersAndLevels)?.install();
-
+fn verbs(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<sim::EmptyEnv>()?;
     m.add_class::<sim::ForkEnv>()?;
     Ok(())

--- a/rust/src/sim/empty_env.rs
+++ b/rust/src/sim/empty_env.rs
@@ -110,6 +110,7 @@ impl EmptyEnv {
     /// course of the simulation.
     /// Events are a tuple containing:
     ///
+    /// * Boolean indicating if the transaction was successful
     /// * The selector of the function called
     /// * A vector of logs
     /// * The step the event was generated

--- a/rust/src/sim/fork_env.rs
+++ b/rust/src/sim/fork_env.rs
@@ -146,6 +146,7 @@ impl ForkEnv {
     /// course of the simulation.
     /// Events are a tuple containing:
     ///
+    /// * Boolean indicating if the transaction was successful
     /// * The selector of the function called
     /// * A vector of logs
     /// * The step the event was generated

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -18,12 +18,13 @@ pub fn bytes_to_py(py: Python, bytes: Bytes) -> &PyBytes {
 
 pub type PyLog<'a> = (&'a PyBytes, &'a PyBytes);
 
-pub type PyEvent<'a> = (&'a PyBytes, Vec<PyLog<'a>>, usize, usize);
+pub type PyEvent<'a> = (bool, &'a PyBytes, Vec<PyLog<'a>>, usize, usize);
 
 pub type PyExecutionResult<'a> = (Option<&'a PyBytes>, Vec<PyLog<'a>>, u64);
 
 pub fn event_to_py<'a>(py: Python<'a>, event: &Event) -> PyEvent<'a> {
     (
+        event.success,
         PyBytes::new(py, &event.function_selector),
         event
             .logs

--- a/src/verbs/utils.py
+++ b/src/verbs/utils.py
@@ -6,6 +6,7 @@ import typing
 
 import eth_abi
 import eth_utils
+import pandas as pd
 from solcx import compile_files, install_solc
 
 import verbs.types
@@ -216,3 +217,32 @@ def cache_from_json(cache_json: typing.List) -> verbs.types.Cache:
         for x in cache_json[3]
     ]
     return (cache_json[0], cache_json[1], accounts, storage)
+
+
+def events_to_dataframe(events: typing.List[typing.Tuple]) -> pd.DataFrame:
+    """
+    Convert a list of event tuples to a Pandas dataframe
+
+    Convert a list of events returned from
+    :py:meth:`verbs.envs.EmptyEnv.get_event_history` to
+    a Pandas dataframe. Note that brevity the dataframe
+    omits the logs attached to the events.
+
+    Parameters
+    ----------
+    events: list
+        List of tuples representing simulation events.
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe containing records of simulation events
+    """
+
+    columns = ["success", "selector", "step", "sequence"]
+
+    df = pd.DataFrame.from_records(
+        [(x[0], x[1], x[3], x[4]) for x in events], columns=columns
+    )
+
+    return df


### PR DESCRIPTION
- Remove pyo3 logs, need to properly investigate performance impact
- Keep records of reverted transactions (rather than just logging them)
- Add utils to convert list of events to a dataframe
- Remove some other unused cargo dependencies